### PR TITLE
Simplify testing middleware

### DIFF
--- a/buzz.go
+++ b/buzz.go
@@ -26,3 +26,12 @@ func (chain *CallChain) Next(ctx context.Context) error {
 
 // MiddleFunc defines the type of any middleware that can be used in the hive.
 type MiddleFunc func(ctx context.Context, chain *CallChain) error
+
+// NewTestCallChain creates a new [CallChain] that simply executes the given [MiddleFunc].
+// The provided [MiddleFunc] will recieve a nil [CallChain]. This function is a utility to
+// make it easy to test your own middleware.
+func NewTestCallChain(exec MiddleFunc) *CallChain {
+	return &CallChain{
+		exec: exec,
+	}
+}

--- a/external_test.go
+++ b/external_test.go
@@ -3,6 +3,7 @@ package buzz_test
 import (
 	"context"
 	"log"
+	"testing"
 
 	"github.com/thenorthnate/buzz"
 )
@@ -30,4 +31,14 @@ func Example() {
 	hive.Submit(worker)
 	// Some time later... during shutdown
 	hive.StopAll()
+}
+
+func TestNewTestCallChain(t *testing.T) {
+	middleware := func(ctx context.Context, chain *buzz.CallChain) error {
+		return nil
+	}
+	chain := buzz.NewTestCallChain(middleware)
+	if err := chain.Next(context.Background()); err != nil {
+		t.Fatal("got unexpected error ", err)
+	}
 }


### PR DESCRIPTION
This makes it easier to test your middleware by making it simple to mock the call chain when calling `Next`.